### PR TITLE
Bugfixes for IEstimation implementations

### DIFF
--- a/Cave.Extensions/Progress/Estimation.cs
+++ b/Cave.Extensions/Progress/Estimation.cs
@@ -191,7 +191,7 @@ public abstract class Estimation : IEstimation
                 return;
             }
             items.Add(item);
-            while (items.Count > MaximumItems)
+            while (MaximumItems > 0 && items.Count > MaximumItems)
             {
                 RemoveOneProgressItem();
             }

--- a/Cave.Extensions/Progress/LinearEstimation.cs
+++ b/Cave.Extensions/Progress/LinearEstimation.cs
@@ -4,14 +4,24 @@ using System;
 
 namespace Cave.Progress;
 
-/// <summary>
-/// Provides a simple linear estimation.
-/// </summary>
+/// <summary>Provides a simple linear estimation.</summary>
 public class LinearEstimation : Estimation
 {
-    /// <inheritdoc/>
-    public override DateTime EstimatedCompletionTime => MonotonicTime.UtcNow + EstimatedTimeLeft;
+    #region Public Properties
 
     /// <inheritdoc/>
-    public override TimeSpan EstimatedTimeLeft => new((long)((MonotonicTime.UtcNow - Started).Ticks * (1 - Progress)));
+    public override DateTime EstimatedCompletionTime => Progress < 0.01f ? MonotonicTime.UtcNow.AddDays(1) : Started.AddTicks((long)((MonotonicTime.UtcNow - Started).Ticks / Progress));
+
+    /// <inheritdoc/>
+    public override TimeSpan EstimatedTimeLeft
+    {
+        get
+        {
+            if (Progress <= 0.01f) return TimeSpan.FromDays(1);
+            var now = MonotonicTime.UtcNow;
+            return Started.AddTicks((long)((now - Started).Ticks / Progress)) - now;
+        }
+    }
+
+    #endregion Public Properties
 }


### PR DESCRIPTION
- LinearEstimation returns a valid result
- Estimation no longer tries to remove cached items when MaximumItems is set to <=0